### PR TITLE
Update components

### DIFF
--- a/components/landing_zone_security_group/.terrahub.yml
+++ b/components/landing_zone_security_group/.terrahub.yml
@@ -38,5 +38,5 @@ component:
         value: aws_security_group.landing_zone_security_group.*.id
       landing_zone_security_group_ids:
         value: >-
-          { for sg in aws_security_group.landing_zone_security_group.*: sg.name
-          => sg.id }
+          { for sg in aws_security_group.landing_zone_security_group.*:
+          sg.tags["Name"] => sg.id }

--- a/components/landing_zone_vpc_peering_connection/.terrahub.yml
+++ b/components/landing_zone_vpc_peering_connection/.terrahub.yml
@@ -23,14 +23,14 @@ component:
           count: >-
             length(var.${tfvar.terrahub["landing_zone_providers"]["0"]}_provider["landing_zone_vpc_peering_connection_resource"])
           vpc_id: >-
-            ${local.elements_landing_zone_vpc_peering_connection_map["config_${count.index}"]["reverse"]
+            local.elements_landing_zone_vpc_peering_connection_map["config_${count.index}"]["reverse"]
             ? element(data.aws_vpc.peer_vpc_selected.*.id, count.index) :
-            local.elements_landing_zone_vpc_peering_connection_map["config_${count.index}"]["vpc_id"]}
+            local.elements_landing_zone_vpc_peering_connection_map["config_${count.index}"]["vpc_id"]
           peer_vpc_id: >-
-            ${local.elements_landing_zone_vpc_peering_connection_map["config_${count.index}"]["reverse"]
+            local.elements_landing_zone_vpc_peering_connection_map["config_${count.index}"]["reverse"]
             ?
             local.elements_landing_zone_vpc_peering_connection_map["config_${count.index}"]["vpc_id"]
-            : element(data.aws_vpc.peer_vpc_selected.*.id, count.index)}
+            : element(data.aws_vpc.peer_vpc_selected.*.id, count.index)
           peer_region: >-
             local.elements_landing_zone_vpc_peering_connection_map["config_${count.index}"]["peer_region"]
           tags: >-


### PR DESCRIPTION
## Description
- some minor improvements
```
Warning: Interpolation-only expressions are deprecated

[landing_zone_vpc_peering_connection] {local.elements_landing_zone_vpc_peering_connection_map_terrahub["config_${count.index}"]["reverse"] ? element(data.aws_vpc.peer_vpc_selected_terrahub.*.id, count.index) : local.elements_landing_zone_vpc_peering_connection_map_terrahub["config_${count.index}"]["vpc_id"]}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.
```

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a change to the documentation

## How Has This Been Tested?
- terrahub run

### Test Configuration
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked that my changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
