### PR TITLE
minor improvements

### DIFF
--- a/modules/landing_zone/main.tf
+++ b/modules/landing_zone/main.tf
@@ -1,6 +1,6 @@
 resource "null_resource" "terraform_output" {
   provisioner "local-exec" {
-    command = "touch ${pathexpand(var.terraform_output_path)}"
+    command = "touch ${pathexpand(var.terraform_output_path)} && npm install"
   }
 }
 

--- a/terraform.local.tfvars
+++ b/terraform.local.tfvars
@@ -60,7 +60,6 @@ landing_zone_components = {
   landing_zone_ssm_maintenance_window               = "./*.tfvars"
   landing_zone_ssm_maintenance_window_target        = "./*.tfvars"
   landing_zone_ssm_parameter                        = "./*.tfvars"
-  landing_zone_sso                                  = "./*.tfvars"
   landing_zone_sns_platform_application             = "./*.tfvars"
   landing_zone_sns_sms_preferences                  = "./*.tfvars"
   landing_zone_sns_topic                            = "./*.tfvars"

--- a/terraform.remote.tfvars
+++ b/terraform.remote.tfvars
@@ -60,7 +60,6 @@ landing_zone_components = {
   landing_zone_ssm_maintenance_window               = "s3://terraform-aws-landing-zone/components/landing_zone_ssm_maintenance_window/*.tfvars"
   landing_zone_ssm_maintenance_window_target        = "s3://terraform-aws-landing-zone/components/landing_zone_ssm_maintenance_window_target/*.tfvars"
   landing_zone_ssm_parameter                        = "s3://terraform-aws-landing-zone/components/landing_zone_ssm_parameter/*.tfvars"
-  landing_zone_sso                                  = "s3://terraform-aws-landing-zone/components/landing_zone_sso/*.tfvars"
   landing_zone_sns_platform_application             = "s3://terraform-aws-landing-zone/components/landing_zone_sns_platform_application/*.tfvars"
   landing_zone_sns_sms_preferences                  = "s3://terraform-aws-landing-zone/components/landing_zone_sns_sms_preferences/*.tfvars"
   landing_zone_sns_topic                            = "s3://terraform-aws-landing-zone/components/landing_zone_sns_topic/*.tfvars"


### PR DESCRIPTION
## Description
- minor improvements

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a change to the documentation

## How Has This Been Tested?
```
root@DESKTOP-ECSQPB1:/mnt/c/Terrahub/terraform-aws-landing-zone# terraform apply

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # module.landing_zone.data.local_file.landing_zone_output_file will be read during apply
  # (config refers to values not yet known)
 <= data "local_file" "landing_zone_output_file"  {
      + content        = (known after apply)
      + content_base64 = (known after apply)
      + filename       = "/tmp/.terrahub/landing_zone/output.json"
      + id             = (known after apply)
    }

  # module.landing_zone.null_resource.landing_zone_apply[0] will be created
  + resource "null_resource" "landing_zone_apply" {
      + id       = (known after apply)
      + triggers = (known after apply)
    }

  # module.landing_zone.null_resource.landing_zone_config[0] will be created
  + resource "null_resource" "landing_zone_config" {
      + id       = (known after apply)
      + triggers = {
          + "backend"     = jsonencode(
                {
                  + backend = "local"
                  + path    = "/tmp/.terrahub/landing_zone"
                }
            )
          + "components"  = jsonencode(
                {
                  + landing_zone_vpc = "./*.tfvars"
                }
            )
          + "module_path" = "modules/landing_zone"
          + "providers"   = jsonencode(
                {
                  + default = {
                      + account_id = "123465789012"
                      + region     = "us-east-1"
                    }
                }
            )
          + "root_path"   = "."
        }
    }

  # module.landing_zone.null_resource.landing_zone_destroy[0] will be created
  + resource "null_resource" "landing_zone_destroy" {
      + id       = (known after apply)
      + triggers = {
          + "components"  = jsonencode(
                {
                  + landing_zone_vpc = "./*.tfvars"
                }
            )
          + "module_path" = "modules/landing_zone"
          + "root_path"   = "."
        }
    }

  # module.landing_zone.null_resource.terraform_config will be created
  + resource "null_resource" "terraform_config" {
      + id       = (known after apply)
      + triggers = {
          + "config" = "true"
          + "root"   = ".terrahub.yml"
          + "sample" = ".terrahub.yml.sample"
        }
    }

  # module.landing_zone.null_resource.terraform_output will be created
  + resource "null_resource" "terraform_output" {
      + id = (known after apply)
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.landing_zone.null_resource.terraform_output: Creating...
module.landing_zone.null_resource.terraform_output: Provisioning with 'local-exec'...
module.landing_zone.null_resource.terraform_output (local-exec): Executing: ["/bin/sh" "-c" "touch /tmp/.terrahub/landing_zone/output.json && npm install"]
module.landing_zone.null_resource.terraform_output: Still creating... [10s elapsed]
module.landing_zone.null_resource.terraform_output (local-exec): npm WARN ws@7.2.1 requires a peer of bufferutil@^4.0.1 but none is installed. You must install peer dependencies yourself.
module.landing_zone.null_resource.terraform_output (local-exec): npm WARN ws@7.2.1 requires a peer of utf-8-validate@^5.0.2 but none is installed. You must install peer dependencies yourself.

module.landing_zone.null_resource.terraform_output (local-exec): audited 1001 packages in 12.127s
module.landing_zone.null_resource.terraform_output (local-exec): found 0 vulnerabilities

module.landing_zone.null_resource.terraform_output: Creation complete after 16s [id=5059967952474765075]
module.landing_zone.null_resource.terraform_config: Creating...
module.landing_zone.null_resource.terraform_config: Provisioning with 'local-exec'...
module.landing_zone.null_resource.terraform_config (local-exec): Executing: ["/bin/sh" "-c" "cp .terrahub.yml.sample .terrahub.yml"]
module.landing_zone.null_resource.terraform_config: Creation complete after 0s [id=345074604376416061]
module.landing_zone.null_resource.landing_zone_config[0]: Creating...
module.landing_zone.null_resource.landing_zone_config[0]: Provisioning with 'local-exec'...
module.landing_zone.null_resource.landing_zone_config[0] (local-exec): Executing: ["/bin/sh" "-c" "node modules/landing_zone/scripts/config.js\n"]
module.landing_zone.null_resource.landing_zone_config[0] (local-exec): ✅ Done

module.landing_zone.null_resource.landing_zone_config[0]: Still creating... [10s elapsed]
module.landing_zone.null_resource.landing_zone_config[0] (local-exec): ✅ Done

module.landing_zone.null_resource.landing_zone_config[0] (local-exec): Error: failed to execute command:  terrahub configure --config template.terraform -D -y failed. Enable DEBUG=debug to learn more.
module.landing_zone.null_resource.landing_zone_config[0]: Still creating... [20s elapsed]
module.landing_zone.null_resource.landing_zone_config[0] (local-exec): ✅ Done

module.landing_zone.null_resource.landing_zone_config[0] (local-exec): ✅ Done

module.landing_zone.null_resource.landing_zone_config[0]: Still creating... [30s elapsed]
module.landing_zone.null_resource.landing_zone_config[0] (local-exec): ✅ Done

module.landing_zone.null_resource.landing_zone_config[0]: Still creating... [40s elapsed]
module.landing_zone.null_resource.landing_zone_config[0] (local-exec): ✅ Done

module.landing_zone.null_resource.landing_zone_config[0] (local-exec): ✅ Done

module.landing_zone.null_resource.landing_zone_config[0]: Still creating... [50s elapsed]
module.landing_zone.null_resource.landing_zone_config[0] (local-exec): ✅ Done

module.landing_zone.null_resource.landing_zone_config[0] (local-exec): ✅ Done

module.landing_zone.null_resource.landing_zone_config[0]: Still creating... [1m0s elapsed]
module.landing_zone.null_resource.landing_zone_config[0] (local-exec): ✅ Done

module.landing_zone.null_resource.landing_zone_config[0] (local-exec): ✅ Done

module.landing_zone.null_resource.landing_zone_config[0]: Still creating... [1m10s elapsed]
module.landing_zone.null_resource.landing_zone_config[0] (local-exec): ✅ Done

module.landing_zone.null_resource.landing_zone_config[0]: Still creating... [1m20s elapsed]
module.landing_zone.null_resource.landing_zone_config[0] (local-exec): ✅ Done

module.landing_zone.null_resource.landing_zone_config[0] (local-exec): ✅ Done

module.landing_zone.null_resource.landing_zone_config[0]: Still creating... [1m30s elapsed]
module.landing_zone.null_resource.landing_zone_config[0] (local-exec): Error: failed to execute command:  terrahub configure --config terraform --include landing_zone_vpc --delete --auto-approve failed. Enable DEBUG=debug to learn more.
module.landing_zone.null_resource.landing_zone_config[0] (local-exec): ✅ Done

module.landing_zone.null_resource.landing_zone_config[0]: Still creating... [1m40s elapsed]
module.landing_zone.null_resource.landing_zone_config[0] (local-exec): ✅ Done

module.landing_zone.null_resource.landing_zone_config[0] (local-exec): ✅ Done

module.landing_zone.null_resource.landing_zone_config[0]: Still creating... [1m50s elapsed]
module.landing_zone.null_resource.landing_zone_config[0] (local-exec): ✅ Done

module.landing_zone.null_resource.landing_zone_config[0] (local-exec): ✅ Done

module.landing_zone.null_resource.landing_zone_config[0]: Still creating... [2m0s elapsed]
module.landing_zone.null_resource.landing_zone_config[0] (local-exec): ✅ Done

module.landing_zone.null_resource.landing_zone_config[0] (local-exec): Success
module.landing_zone.null_resource.landing_zone_config[0]: Creation complete after 2m3s [id=6062391802744441080]
module.landing_zone.null_resource.landing_zone_apply[0]: Creating...
module.landing_zone.null_resource.landing_zone_apply[0]: Provisioning with 'local-exec'...
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): Executing: ["/bin/sh" "-c" "node modules/landing_zone/scripts/apply.js\n"]
module.landing_zone.null_resource.landing_zone_apply[0]: Still creating... [10s elapsed]
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): Project: terraform-aws-landing-zone
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec):  └─ landing_zone_vpc
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): ✅ [landing_zone_vpc] Build successfully finished.
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): ✅ Done

module.landing_zone.null_resource.landing_zone_apply[0]: Still creating... [20s elapsed]
module.landing_zone.null_resource.landing_zone_apply[0]: Still creating... [30s elapsed]
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): Project: terraform-aws-landing-zone
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec):  └─ landing_zone_vpc
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): [landing_zone_vpc]
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): Initializing the backend...
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): [landing_zone_vpc]
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): Initializing provider plugins...
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): [landing_zone_vpc]
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): The following providers do not have any version constraints in configuration,
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): so the latest version was installed.

module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): To prevent automatic upgrades to new major versions that may contain breaking
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): changes, it is recommended to add version = "..." constraints to the
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): corresponding provider blocks in configuration, with the constraint strings
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): suggested below.

module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): * provider.aws: version = "~> 2.43"

module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): Terraform has been successfully initialized!

module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): You may now begin working with Terraform. Try running "terraform plan" to see
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): any changes that are required for your infrastructure. All Terraform commands
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): should now work.

module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): If you ever set or change modules or backend configuration for Terraform,
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): rerun this command to reinitialize your working directory. If you forget, other
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): commands will detect it and remind you to do so if necessary.
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): ✅ Done

module.landing_zone.null_resource.landing_zone_apply[0]: Still creating... [40s elapsed]
module.landing_zone.null_resource.landing_zone_apply[0]: Still creating... [50s elapsed]
module.landing_zone.null_resource.landing_zone_apply[0]: Still creating... [1m0s elapsed]
module.landing_zone.null_resource.landing_zone_apply[0]: Still creating... [1m10s elapsed]
module.landing_zone.null_resource.landing_zone_apply[0]: Still creating... [1m20s elapsed]
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): Project: terraform-aws-landing-zone
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec):  └─ landing_zone_vpc
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): Option 'auto-approve' is enabled, therefore 'apply' action is executed with no confirmation.
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): [landing_zone_vpc] * default

module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): [landing_zone_vpc] Refreshing Terraform state in-memory prior to plan...
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): The refreshed state will be used to calculate this plan, but will not be
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): persisted to local or remote state storage.

module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): [landing_zone_vpc] aws_vpc.landing_zone_vpc[0]: Refreshing state... [id=vpc-0c123465789012af]
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): [landing_zone_vpc]
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): ------------------------------------------------------------------------
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): [landing_zone_vpc]
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): No changes. Infrastructure is up-to-date.

module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): This means that Terraform did not detect any differences between your
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): [landing_zone_vpc] configuration and real physical resources that exist. As a result, no
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): [landing_zone_vpc] actions need to be performed.
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): [landing_zone_vpc] {
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec):   "default" = [
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec):     "arn:aws:ec2:us-east-1:123465789012:vpc/vpc-0c123465789012af",
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec):   ]
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): }
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): ids = {
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec):   "default" = [
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec):     "vpc-0c123465789012af",
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec):   ]
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): }
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): landing_zone_vpc_arns = {
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec):   "default" = {
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec):     "ecc740d07169d9132911659bc627eab32c98213d" = "arn:aws:ec2:us-east-1:123465789012:vpc/vpc-0c123465789012af"
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec):   }
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): }
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): landing_zone_vpc_ids = {
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec):   "default" = {
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec):     "ecc740d07169d9132911659bc627eab32c98213d" = "vpc-0c123465789012af"
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec):   }
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): }
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): thub_ids = {
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec):   "default" = [
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec):     "vpc-0c123465789012af",
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec):   ]
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): }
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): ✅ Done

module.landing_zone.null_resource.landing_zone_apply[0]: Still creating... [1m30s elapsed]
module.landing_zone.null_resource.landing_zone_apply[0] (local-exec): Success
module.landing_zone.null_resource.landing_zone_apply[0]: Creation complete after 1m35s [id=3193025994944609149]
module.landing_zone.data.local_file.landing_zone_output_file: Refreshing state...
module.landing_zone.null_resource.landing_zone_destroy[0]: Creating...
module.landing_zone.null_resource.landing_zone_destroy[0]: Provisioning with 'local-exec'...
module.landing_zone.null_resource.landing_zone_destroy[0] (local-exec): Executing: ["/bin/sh" "-c" "echo 'info: apply action ignored because part of landing_zone_destroy'"]
module.landing_zone.null_resource.landing_zone_destroy[0] (local-exec): info: apply action ignored because part of landing_zone_destroy
module.landing_zone.null_resource.landing_zone_destroy[0]: Creation complete after 0s [id=2271216442014236068]

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

landing_zone_cloudtrail_arn = Is not set!
landing_zone_cloudtrail_id = Is not set!
landing_zone_cloudtrail_s3_bucket_arn = Is not set!
landing_zone_cloudtrail_s3_bucket_bucket = Is not set!
landing_zone_cloudtrail_s3_bucket_id = Is not set!
landing_zone_code_build_arn = Is not set!
landing_zone_code_build_badge_url = Is not set!
landing_zone_code_build_id = Is not set!
landing_zone_code_build_role_arn = Is not set!
landing_zone_code_build_role_id = Is not set!
landing_zone_code_build_role_name = Is not set!
landing_zone_code_pipeline_arn = Is not set!
landing_zone_code_pipeline_id = Is not set!
landing_zone_code_pipeline_role_id = Is not set!
landing_zone_code_pipeline_role_name = Is not set!
landing_zone_config_aggregate_authorization_arns = Is not set!
landing_zone_config_config_rule_arns = Is not set!
landing_zone_config_config_rule_rule_ids = Is not set!
landing_zone_config_configuration_aggregator_arns = Is not set!
landing_zone_config_configuration_recorder_ids = Is not set!
landing_zone_config_delivery_channel_ids = Is not set!
landing_zone_config_organization_custom_rule_arns = Is not set!
landing_zone_config_organization_managed_rule_arns = Is not set!
landing_zone_directory_service_directory_access_urls = Is not set!
landing_zone_directory_service_directory_aliases = Is not set!
landing_zone_directory_service_directory_ids = Is not set!
landing_zone_eip_ids = Is not set!
landing_zone_eip_public_ips = Is not set!
landing_zone_gateway_cgw_ids = Is not set!
landing_zone_gateway_igw_ids = Is not set!
landing_zone_gateway_nat_ids = Is not set!
landing_zone_gateway_nat_network_interface_ids = Is not set!
landing_zone_gateway_tgw_ids = Is not set!
landing_zone_gateway_vgw_ids = Is not set!
landing_zone_guardduty_detector_account_ids = Is not set!
landing_zone_guardduty_detector_ids = Is not set!
landing_zone_guardduty_invite_accepter_ids = Is not set!
landing_zone_guardduty_member_ids = Is not set!
landing_zone_guardduty_member_relationship_statuses = Is not set!
landing_zone_iam_instance_profile_arns = Is not set!
landing_zone_iam_instance_profile_ids = Is not set!
landing_zone_iam_instance_profile_names = Is not set!
landing_zone_iam_instance_profile_paths = Is not set!
landing_zone_iam_instance_profile_roles = Is not set!
landing_zone_iam_policy_ids = Is not set!
landing_zone_iam_policy_names = Is not set!
landing_zone_iam_policy_policies = Is not set!
landing_zone_iam_role_arns = Is not set!
landing_zone_iam_role_ids = Is not set!
landing_zone_iam_role_names = Is not set!
landing_zone_network_acl_ids = Is not set!
landing_zone_organization_accounts = Is not set!
landing_zone_organization_accounts_arns = Is not set!
landing_zone_organization_accounts_ids = Is not set!
landing_zone_organization_accounts_non_master_arns = Is not set!
landing_zone_organization_accounts_non_master_ids = Is not set!
landing_zone_organization_id = Is not set!
landing_zone_organization_roots = Is not set!
landing_zone_organization_unit_accounts = Is not set!
landing_zone_organization_unit_arn = Is not set!
landing_zone_organization_unit_id = Is not set!
landing_zone_pipeline_artifact_s3_bucket_arn = Is not set!
landing_zone_pipeline_artifact_s3_bucket_bucket = Is not set!
landing_zone_pipeline_artifact_s3_bucket_id = Is not set!
landing_zone_pipeline_s3_bucket_arn = Is not set!
landing_zone_pipeline_s3_bucket_bucket = Is not set!
landing_zone_pipeline_s3_bucket_id = Is not set!
landing_zone_route_cgw_ids = Is not set!
landing_zone_route_ids = Is not set!
landing_zone_route_igw_ids = Is not set!
landing_zone_route_ipv6_ids = Is not set!
landing_zone_route_nat_ids = Is not set!
landing_zone_route_pcx_ids = Is not set!
landing_zone_route_table_association_ids = Is not set!
landing_zone_route_table_association_tgw_ids = Is not set!
landing_zone_route_table_ids = Is not set!
landing_zone_route_table_tgw_ids = Is not set!
landing_zone_route_vgw_ids = Is not set!
landing_zone_secretsmanager_secret_arns = Is not set!
landing_zone_secretsmanager_secret_ids = Is not set!
landing_zone_security_group_ids = Is not set!
landing_zone_sns_platform_application_arns = Is not set!
landing_zone_sns_platform_application_ids = Is not set!
landing_zone_sns_topic_arns = Is not set!
landing_zone_sns_topic_ids = Is not set!
landing_zone_sns_topic_subscription_arns = Is not set!
landing_zone_sns_topic_subscription_endpoints = Is not set!
landing_zone_sns_topic_subscription_ids = Is not set!
landing_zone_sns_topic_subscription_protocols = Is not set!
landing_zone_sns_topic_subscription_topic_arns = Is not set!
landing_zone_ssm_activation_ids = Is not set!
landing_zone_ssm_association_by_instance_id_ids = Is not set!
landing_zone_ssm_association_by_instance_id_names = Is not set!
landing_zone_ssm_association_by_targets_ids = Is not set!
landing_zone_ssm_association_by_targets_names = Is not set!
landing_zone_ssm_document_created_dates = Is not set!
landing_zone_ssm_document_hashes = Is not set!
landing_zone_ssm_maintenance_window_ids = Is not set!
landing_zone_ssm_maintenance_window_target_ids = Is not set!
landing_zone_ssm_parameter_arns = Is not set!
landing_zone_ssm_parameter_names = Is not set!
landing_zone_ssm_patch_baseline_ids = Is not set!
landing_zone_ssm_patch_group_ids = Is not set!
landing_zone_subnet_arns = Is not set!
landing_zone_subnet_availability_zone_ids = Is not set!
landing_zone_subnet_ids = Is not set!
landing_zone_tgw_route_ids = Is not set!
landing_zone_tgw_route_table_association_ids = Is not set!
landing_zone_tgw_route_table_ids = Is not set!
landing_zone_tgw_route_table_propagation_ids = Is not set!
landing_zone_tgw_vpc_accepter_attachment_ids = Is not set!
landing_zone_tgw_vpc_attachment_ids = Is not set!
landing_zone_vpc_arns = {
  "default" = {
    "ecc740d07169d9132911659bc627eab32c98213d" = "arn:aws:ec2:us-east-1:123465789012:vpc/vpc-0c123465789012af"
  }
}
landing_zone_vpc_endpoint_gateway_ids = Is not set!
landing_zone_vpc_endpoint_interface_ids = Is not set!
landing_zone_vpc_ids = {
  "default" = {
    "ecc740d07169d9132911659bc627eab32c98213d" = "vpc-0c123465789012af"
  }
}
landing_zone_vpc_peering_connection_ids = Is not set!
```

### Test Configuration
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked that my changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
