### PR TITLE
minor improvements

### DIFF
--- a/modules/landing_zone/data.tf
+++ b/modules/landing_zone/data.tf
@@ -1,4 +1,7 @@
 data "local_file" "landing_zone_output_file" {
-  depends_on = [null_resource.landing_zone_apply]
+  depends_on = [
+    null_resource.terraform_output,
+    null_resource.landing_zone_apply
+  ]
   filename   = pathexpand(var.terraform_output_path)
 }

--- a/modules/landing_zone/main.tf
+++ b/modules/landing_zone/main.tf
@@ -6,6 +6,8 @@ resource "null_resource" "terraform_output" {
 
 resource "null_resource" "terraform_config" {
   depends_on = [null_resource.terraform_output]
+  count      = length(var.landing_zone_components) == 0 ? 0 : 1
+
   triggers = {
     config = var.terraform_config
     sample = ".terrahub.yml.sample"

--- a/modules/landing_zone/output.tf
+++ b/modules/landing_zone/output.tf
@@ -1,6 +1,6 @@
 output "landing_zone" {
   depends_on  = [data.local_file.landing_zone_output_file]
   sensitive   = true
-  value       = data.local_file.landing_zone_output_file.content == "" ? jsondecode("\"null\":{\"default\":[\"null\"]}") : jsondecode(data.local_file.landing_zone_output_file.content)
+  value       = data.local_file.landing_zone_output_file.content == "" ? jsondecode("{\"null\":{\"default\":[\"null\"]}}") : jsondecode(data.local_file.landing_zone_output_file.content)
   description = "The map of all output variables from components."
 }


### PR DESCRIPTION
## Description
- fixed `data.local_file.landing_zone_output_file` depends_on
- fixed `null_resource.terraform_config` count
- fixed `output` JSON

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a change to the documentation

## How Has This Been Tested?
```
root@DESKTOP-ECSQPB1:/mnt/c/Terrahub/terraform-aws-landing-zone-reader# terraform apply

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.terraform_remote_state.landing_zone_reader_output will be read during apply
  # (config refers to values not yet known)
 <= data "terraform_remote_state" "landing_zone_reader_output"  {
      + backend = "s3"
      + config  = {
          + "bucket" = "terraform-aws-landing-zone-account3"
          + "key"    = "terraform/landing_zone_reader_output/terraform.tfstate"
          + "region" = "us-east-1"
        }
      + outputs = (known after apply)
    }

  # module.landing_zone_reader_config.null_resource.landing_zone_reader_apply[0] will be created
  + resource "null_resource" "landing_zone_reader_apply" {
      + id       = (known after apply)
      + triggers = (known after apply)
    }

  # module.landing_zone_reader_config.null_resource.landing_zone_reader_config[0] will be created
  + resource "null_resource" "landing_zone_reader_config" {
      + id       = (known after apply)
      + triggers = {
          + "backend"     = jsonencode(
                {
                  + backend = "s3"
                  + bucket  = "terraform-aws-landing-zone-account3"
                  + key     = "terraform"
                  + region  = "us-east-1"
                }
            )
          + "components"  = jsonencode(
                {
                  + landing_zone_vpc = "s3://terraform-aws-landing-zone-account3/components/landing_zone_vpc/*.tfvars"
                }
            )
          + "module_path" = "modules/landing_zone_reader_config"
          + "providers"   = jsonencode(
                {
                  + account1 = {
                      + account_id = "123456789012"
                      + region     = "us-east-1"
                    }
                  + default        = {
                      + account_id = "123456789013"
                      + region     = "us-east-1"
                    }
                  + account2      = {
                      + account_id = "123456789014"
                      + region     = "us-east-1"
                    }
                  + account3     = {
                      + account_id = "123456789015"
                      + region     = "us-east-1"
                    }
                  + account4       = {
                      + account_id = "123456789016"
                      + region     = "us-east-1"
                    }
                  + account5        = {
                      + account_id = "123456789017"
                      + region     = "us-east-1"
                    }
                }
            )
          + "root_path"   = "."
        }
    }

  # module.landing_zone_reader_config.null_resource.terraform_config will be created
  + resource "null_resource" "terraform_config" {
      + id       = (known after apply)
      + triggers = {
          + "config" = "true"
          + "root"   = ".account4.yml"
          + "sample" = ".account4.yml.sample"
        }
    }

  # module.landing_zone_reader_config.null_resource.terraform_output will be created
  + resource "null_resource" "terraform_output" {
      + id = (known after apply)
    }

  # module.landing_zone.module.landing_zone.data.local_file.landing_zone_output_file will be read during apply
  # (config refers to values not yet known)
 <= data "local_file" "landing_zone_output_file"  {
      + content        = (known after apply)
      + content_base64 = (known after apply)
      + filename       = "/tmp/.account4/landing_zone/output.json"
      + id             = (known after apply)
    }

  # module.landing_zone.module.landing_zone.null_resource.terraform_output will be created
  + resource "null_resource" "terraform_output" {
      + id = (known after apply)
    }

Plan: 5 to add, 0 to change, 0 to destroy.


Warning: Value for undeclared variable

  on terraform.tfvars line 43:
  43: terraform_backend = {
  44:   backend = "s3"
  45:   region  = "us-east-1"
  46:   bucket  = "terraform-aws-landing-zone-account3"
  47:   key     = "terraform"
  48: }

The root module does not declare a variable named "terraform_backend". To use
this value, add a "variable" block to the configuration.

Using a variables file to set an undeclared variable is deprecated and will
become an error in a future release. If you wish to provide certain "global"
settings to all configurations in your organization, use TF_VAR_...
environment variables to set these instead.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.landing_zone.module.landing_zone.null_resource.terraform_output: Creating...
module.landing_zone_reader_config.null_resource.terraform_output: Creating...
module.landing_zone_reader_config.null_resource.terraform_output: Provisioning with 'local-exec'...
module.landing_zone.module.landing_zone.null_resource.terraform_output: Provisioning with 'local-exec'...
module.landing_zone_reader_config.null_resource.terraform_output (local-exec): Executing: ["/bin/sh" "-c" "mkdir -p $(dirname '/tmp/.account4/landing_zone/output.json') && touch /tmp/.account4/landing_zone/output.json && npm install"]
module.landing_zone.module.landing_zone.null_resource.terraform_output (local-exec): Executing: ["/bin/sh" "-c" "mkdir -p $(dirname '/tmp/.account4/landing_zone/output.json') && touch /tmp/.account4/landing_zone/output.json && npm install"]
module.landing_zone.module.landing_zone.null_resource.terraform_output: Still creating... [10s elapsed]
module.landing_zone_reader_config.null_resource.terraform_output: Still creating... [10s elapsed]
module.landing_zone.module.landing_zone.null_resource.terraform_output: Still creating... [20s elapsed]
module.landing_zone_reader_config.null_resource.terraform_output: Still creating... [20s elapsed]
module.landing_zone.module.landing_zone.null_resource.terraform_output: Still creating... [30s elapsed]
module.landing_zone_reader_config.null_resource.terraform_output: Still creating... [30s elapsed]
module.landing_zone_reader_config.null_resource.terraform_output (local-exec): npm WARN ws@7.2.1 requires a peer of bufferutil@^4.0.1 but none is installed. You must install peer dependencies yourself.
module.landing_zone_reader_config.null_resource.terraform_output (local-exec): npm WARN ws@7.2.1 requires a peer of utf-8-validate@^5.0.2 but none is installed. You must install peer dependencies yourself.

module.landing_zone_reader_config.null_resource.terraform_output (local-exec): audited 1052 packages in 25.545s
module.landing_zone_reader_config.null_resource.terraform_output (local-exec): found 0 vulnerabilities

module.landing_zone_reader_config.null_resource.terraform_output: Creation complete after 31s [id=9065928404434914504]
module.landing_zone_reader_config.null_resource.terraform_config: Creating...
module.landing_zone_reader_config.null_resource.terraform_config: Provisioning with 'local-exec'...
module.landing_zone_reader_config.null_resource.terraform_config (local-exec): Executing: ["/bin/sh" "-c" "cp .account4.yml.sample .account4.yml"]
module.landing_zone.module.landing_zone.null_resource.terraform_output (local-exec): npm WARN ws@7.2.1 requires a peer of bufferutil@^4.0.1 but none is installed. You must install peer dependencies yourself.
module.landing_zone.module.landing_zone.null_resource.terraform_output (local-exec): npm WARN ws@7.2.1 requires a peer of utf-8-validate@^5.0.2 but none is installed. You must install peer dependencies yourself.

module.landing_zone.module.landing_zone.null_resource.terraform_output (local-exec): audited 1052 packages in 25.844s
module.landing_zone.module.landing_zone.null_resource.terraform_output (local-exec): found 0 vulnerabilities

module.landing_zone_reader_config.null_resource.terraform_config: Creation complete after 0s [id=8759475350246552203]
module.landing_zone_reader_config.null_resource.landing_zone_reader_config[0]: Creating...
module.landing_zone_reader_config.null_resource.landing_zone_reader_config[0]: Provisioning with 'local-exec'...
module.landing_zone_reader_config.null_resource.landing_zone_reader_config[0] (local-exec): Executing: ["/bin/sh" "-c" "node modules/landing_zone_reader_config/scripts/config.js\n"]
module.landing_zone.module.landing_zone.null_resource.terraform_output: Creation complete after 31s [id=2546826421267555793]
module.landing_zone.module.landing_zone.data.local_file.landing_zone_output_file: Refreshing state...
module.landing_zone_reader_config.null_resource.landing_zone_reader_config[0]: Still creating... [10s elapsed]
module.landing_zone_reader_config.null_resource.landing_zone_reader_config[0] (local-exec): ✅ Done
...
module.landing_zone_reader_config.null_resource.landing_zone_reader_config[0]: Still creating... [5m20s elapsed]
module.landing_zone_reader_config.null_resource.landing_zone_reader_config[0] (local-exec): ✅ Done

module.landing_zone_reader_config.null_resource.landing_zone_reader_config[0] (local-exec): Success
module.landing_zone_reader_config.null_resource.landing_zone_reader_config[0]: Creation complete after 5m20s [id=1313673781234542569]
module.landing_zone_reader_config.null_resource.landing_zone_reader_apply[0]: Creating...
module.landing_zone_reader_config.null_resource.landing_zone_reader_apply[0]: Provisioning with 'local-exec'...
module.landing_zone_reader_config.null_resource.landing_zone_reader_apply[0] (local-exec): Executing: ["/bin/sh" "-c" "node modules/landing_zone_reader_config/scripts/apply.js\n"]
module.landing_zone_reader_config.null_resource.landing_zone_reader_apply[0] (local-exec): ✅ Done

module.landing_zone_reader_config.null_resource.landing_zone_reader_apply[0]: Still creating... [10s elapsed]
...
module.landing_zone_reader_config.null_resource.landing_zone_reader_apply[0]: Still creating... [2m40s elapsed]
module.landing_zone_reader_config.null_resource.landing_zone_reader_apply[0] (local-exec): Success
module.landing_zone_reader_config.null_resource.landing_zone_reader_apply[0]: Creation complete after 2m48s [id=8200338061764935947]
data.terraform_remote_state.landing_zone_reader_output: Refreshing state...

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

landing_zone_reader = <sensitive>
```

### Test Configuration
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked that my changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
